### PR TITLE
if: Tidy up convert module and make it public

### DIFF
--- a/docs/development/api_reference.md
+++ b/docs/development/api_reference.md
@@ -11,6 +11,8 @@ files:
     description: Configuration and services.
   - name: const.py
     description: Various constants.
+  - name: convert.py
+    description: Conversion methods, e.g. constants to string.
   - name: exceptions.py
     description: Exceptions that are specific to this library.
   - name: helpers.py

--- a/pyatv/convert.py
+++ b/pyatv/convert.py
@@ -1,114 +1,54 @@
 """Various types of extraction and conversion functions."""
 
-from pyatv import exceptions
 from pyatv.const import (
     Protocol, MediaType, DeviceState, RepeatState, ShuffleState)
 
 
-def media_kind(kind):
-    """Convert iTunes media kind to API representation."""
-    if kind in [1, 32770]:
-        return MediaType.Unknown
-    if kind in [3, 7, 11, 12, 13, 18, 32]:
-        return MediaType.Video
-    if kind in [2, 4, 10, 14, 17, 21, 36]:
-        return MediaType.Music
-    if kind in [8, 64]:
-        return MediaType.TV
-
-    raise exceptions.UnknownMediaKindError('Unknown media kind: ' + str(kind))
+def device_state_str(state):
+    """Convert internal API device state to string."""
+    return {
+        None: 'Idle',
+        DeviceState.Idle: 'Idle',
+        DeviceState.Loading: 'Loading',
+        DeviceState.Stopped: 'Stopped',
+        DeviceState.Paused: 'Paused',
+        DeviceState.Playing: 'Playing',
+        DeviceState.Seeking: 'Seeking',
+        }.get(state, 'Unsupported')
 
 
 def media_type_str(mediatype):
     """Convert internal API media type to string."""
-    if mediatype == MediaType.Unknown:
-        return 'Unknown'
-    if mediatype == MediaType.Video:
-        return 'Video'
-    if mediatype == MediaType.Music:
-        return 'Music'
-    if mediatype == MediaType.TV:
-        return 'TV'
-    return 'Unsupported'
-
-
-def playstate(state):
-    """Convert iTunes playstate to API representation."""
-    # pylint: disable=too-many-return-statements
-    if state == 0 or state is None:
-        return DeviceState.Idle
-    if state == 1:
-        return DeviceState.Loading
-    if state == 2:
-        return DeviceState.Stopped
-    if state == 3:
-        return DeviceState.Paused
-    if state == 4:
-        return DeviceState.Playing
-    if state in (5, 6):
-        return DeviceState.Seeking
-
-    raise exceptions.UnknownPlayStateError('Unknown playstate: ' + str(state))
-
-
-# pylint: disable=too-many-return-statements
-def playstate_str(state):
-    """Convert internal API playstate to string."""
-    if state == DeviceState.Idle:
-        return 'Idle'
-    if state == DeviceState.Loading:
-        return 'Loading'
-    if state == DeviceState.Stopped:
-        return 'Stopped'
-    if state == DeviceState.Paused:
-        return 'Paused'
-    if state == DeviceState.Playing:
-        return 'Playing'
-    if state == DeviceState.Seeking:
-        return 'Seeking'
-
-    return 'Unsupported'
+    return {
+        MediaType.Unknown: 'Unknown',
+        MediaType.Video: 'Video',
+        MediaType.Music: 'Music',
+        MediaType.TV: 'TV',
+        }.get(mediatype, 'Unsupported')
 
 
 def repeat_str(state):
     """Convert internal API repeat state to string."""
-    if state == RepeatState.Off:
-        return 'Off'
-    if state == RepeatState.Track:
-        return 'Track'
-    if state == RepeatState.All:
-        return 'All'
-    return 'Unsupported'
+    return {
+        RepeatState.Off: 'Off',
+        RepeatState.Track: 'Track',
+        RepeatState.All: 'All',
+        }.get(state, 'Unsupported')
 
 
 def shuffle_str(state):
     """Convert internal API shuffle state to string."""
-    if state == ShuffleState.Off:
-        return 'Off'
-    if state == ShuffleState.Albums:
-        return 'Albums'
-    if state == ShuffleState.Songs:
-        return 'Songs'
-    return 'Unsupported'
-
-
-def ms_to_s(time):
-    """Convert time in ms to seconds."""
-    if time is None:
-        return 0
-
-    # Happens in some special cases, just return 0
-    if time >= (2**32 - 1):
-        return 0
-    return round(time / 1000.0)
+    return {
+        ShuffleState.Off: 'Off',
+        ShuffleState.Albums: 'Albums',
+        ShuffleState.Songs: 'Songs',
+        }.get(state, 'Unsupported')
 
 
 def protocol_str(protocol):
     """Convert internal API protocol to string."""
-    if protocol == Protocol.MRP:
-        return 'MRP'
-    if protocol == Protocol.DMAP:
-        return 'DMAP'
-    if protocol == Protocol.AirPlay:
-        return 'AirPlay'
-    return 'Unknown'
+    return {
+        Protocol.MRP: 'MRP',
+        Protocol.DMAP: 'DMAP',
+        Protocol.AirPlay: 'AirPlay',
+        }.get(protocol, 'Unknown')

--- a/pyatv/dmap/__init__.py
+++ b/pyatv/dmap/__init__.py
@@ -5,10 +5,10 @@ import asyncio
 
 from aiohttp.client_exceptions import ClientError
 
-from pyatv import (exceptions, convert, net)
+from pyatv import (exceptions, net)
 from pyatv.cache import Cache
 from pyatv.const import Protocol, MediaType, RepeatState, ShuffleState
-from pyatv.dmap import (parser, tags)
+from pyatv.dmap import (daap, parser, tags)
 from pyatv.dmap.daap import DaapRequester
 from pyatv.net import HttpSession
 from pyatv.interface import (AppleTV, RemoteControl, Metadata,
@@ -232,7 +232,7 @@ class DmapPlaying(Playing):
 
         mediakind = parser.first(self.playstatus, 'cmst', 'cmmk')
         if mediakind is not None:
-            return convert.media_kind(mediakind)
+            return daap.media_kind(mediakind)
 
         # Fallback: if artist or album exists we assume music (not present
         # for video)
@@ -245,7 +245,7 @@ class DmapPlaying(Playing):
     def device_state(self):
         """Device state, e.g. playing or paused."""
         state = parser.first(self.playstatus, 'cmst', 'caps')
-        return convert.playstate(state)
+        return daap.playstate(state)
 
     @property
     def title(self):
@@ -298,7 +298,7 @@ class DmapPlaying(Playing):
 
     def _get_time_in_seconds(self, tag):
         time = parser.first(self.playstatus, 'cmst', tag)
-        return convert.ms_to_s(time)
+        return daap.ms_to_s(time)
 
 
 class DmapMetadata(Metadata):

--- a/pyatv/dmap/daap.py
+++ b/pyatv/dmap/daap.py
@@ -7,6 +7,7 @@ from copy import copy
 
 
 from pyatv import exceptions
+from pyatv.const import MediaType, DeviceState
 from pyatv.dmap import parser
 from .tag_definitions import lookup_tag
 
@@ -24,6 +25,50 @@ _DMAP_HEADERS = {
 
 
 DEFAULT_TIMEOUT = 10.0  # Seconds
+
+
+def media_kind(kind):
+    """Convert iTunes media kind to API representation."""
+    if kind in [1, 32770]:
+        return MediaType.Unknown
+    if kind in [3, 7, 11, 12, 13, 18, 32]:
+        return MediaType.Video
+    if kind in [2, 4, 10, 14, 17, 21, 36]:
+        return MediaType.Music
+    if kind in [8, 64]:
+        return MediaType.TV
+
+    raise exceptions.UnknownMediaKindError('Unknown media kind: ' + str(kind))
+
+
+def playstate(state):
+    """Convert iTunes playstate to API representation."""
+    # pylint: disable=too-many-return-statements
+    if state == 0 or state is None:
+        return DeviceState.Idle
+    if state == 1:
+        return DeviceState.Loading
+    if state == 2:
+        return DeviceState.Stopped
+    if state == 3:
+        return DeviceState.Paused
+    if state == 4:
+        return DeviceState.Playing
+    if state in (5, 6):
+        return DeviceState.Seeking
+
+    raise exceptions.UnknownPlayStateError('Unknown playstate: ' + str(state))
+
+
+def ms_to_s(time):
+    """Convert time in ms to seconds."""
+    if time is None:
+        return 0
+
+    # Happens in some special cases, just return 0
+    if time >= (2**32 - 1):
+        return 0
+    return round(time / 1000.0)
 
 
 class DaapRequester:

--- a/pyatv/interface.py
+++ b/pyatv/interface.py
@@ -214,7 +214,7 @@ class Playing:
         output.append('  Media type: {0}'.format(
             convert.media_type_str(self.media_type)))
         output.append('Device state: {0}'.format(
-            convert.playstate_str(self.device_state)))
+            convert.device_state_str(self.device_state)))
 
         if self.title is not None:
             output.append('       Title: {0}'.format(self.title))

--- a/tests/dmap/test_daap.py
+++ b/tests/dmap/test_daap.py
@@ -1,0 +1,146 @@
+"""Unit tests for pyatv.convert."""
+
+import unittest
+
+from pyatv import exceptions
+from pyatv.dmap.daap import media_kind, playstate, ms_to_s
+from pyatv.const import MediaType, DeviceState
+
+# These are extracted from iTunes, see for instance:
+# http://www.blooming.no/wp-content/uploads/2013/03/ITLibMediaItem.h
+# and also this:
+# https://github.com/melloware/dacp-net/blob/master/Melloware.DACP/DACPResponse.cs
+# Key: cmst.cmmk
+MEDIA_KIND_UNKNOWN = 1
+MEDIA_KIND_UNKNOWN2 = 32770  # Reported in #182
+MEDIA_KIND_SONG = 2
+MEDIA_KIND_MOVIE = 3
+MEDIA_KIND_PODCAST = 4
+MEDIA_KIND_AUDIOBOOK = 5
+MEDIA_KIND_PDFBOOKLET = 6
+MEDIA_KIND_MUSICVIDEO = 7
+MEDIA_KIND_TVSHOW = 8
+MEDIA_KIND_INTERACTIVEBOOKLET = 9
+MEDIA_KIND_COACHEDAUDIO = 10
+MEDIA_KIND_VIDEOPASS = 11
+MEDIA_KIND_HOMEVIDEO = 12
+MEDIA_KIND_FUTUREVIDEO = 13
+MEDIA_KIND_RINGTONE = 14
+MEDIA_KIND_DIGITALBOOKLET = 15
+MEDIA_KIND_IOSAPPLICATION = 16
+MEDIA_KIND_VOICEMEMO = 17
+MEDIA_KIND_ITUNESU = 18
+MEDIA_KIND_BOOK = 19
+MEDIA_KIND_PDFBOOK = 20
+MEDIA_KIND_ALERTTONE = 21
+MEDIA_KIND_MUSICVIDEO2 = 32
+MEDIA_KIND_PODCAST2 = 36
+MEDIA_KIND_TVSHOW2 = 64
+
+# Found on various places on the Internet as well as by testing
+# Key: cmst.caps
+PLAY_STATE_IDLE = 0
+PLAY_STATE_LOADING = 1  # E.g. buffering
+PLAY_STATE_STOPPED = 2
+PLAY_STATE_PAUSED = 3
+PLAY_STATE_PLAYING = 4
+PLAY_STATE_FORWARD = 5
+PLAY_STATE_BACKWARD = 6
+
+
+class ConvertTest(unittest.TestCase):
+
+    # MEDIA KIND TESTS
+
+    def test_unknown_media_kind(self):
+        self.assertEqual(MediaType.Unknown,
+                         media_kind(MEDIA_KIND_UNKNOWN))
+        self.assertEqual(MediaType.Unknown,
+                         media_kind(MEDIA_KIND_UNKNOWN2))
+
+    def test_video_media_kinds(self):
+        self.assertEqual(MediaType.Video,
+                         media_kind(MEDIA_KIND_MOVIE))
+        self.assertEqual(MediaType.Video,
+                         media_kind(MEDIA_KIND_MUSICVIDEO))
+        self.assertEqual(MediaType.Video,
+                         media_kind(MEDIA_KIND_MUSICVIDEO2))
+        self.assertEqual(MediaType.Video,
+                         media_kind(MEDIA_KIND_VIDEOPASS))
+        self.assertEqual(MediaType.Video,
+                         media_kind(MEDIA_KIND_HOMEVIDEO))
+        self.assertEqual(MediaType.Video,
+                         media_kind(MEDIA_KIND_FUTUREVIDEO))
+        self.assertEqual(MediaType.Video,
+                         media_kind(MEDIA_KIND_ITUNESU))
+
+    def test_music_media_kinds(self):
+        self.assertEqual(MediaType.Music,
+                         media_kind(MEDIA_KIND_SONG))
+        self.assertEqual(MediaType.Music,
+                         media_kind(MEDIA_KIND_PODCAST))
+        self.assertEqual(MediaType.Music,
+                         media_kind(MEDIA_KIND_PODCAST2))
+        self.assertEqual(MediaType.Music,
+                         media_kind(MEDIA_KIND_COACHEDAUDIO))
+        self.assertEqual(MediaType.Music,
+                         media_kind(MEDIA_KIND_RINGTONE))
+        self.assertEqual(MediaType.Music,
+                         media_kind(MEDIA_KIND_VOICEMEMO))
+        self.assertEqual(MediaType.Music,
+                         media_kind(MEDIA_KIND_ALERTTONE))
+
+    def test_tv_kinds(self):
+        self.assertEqual(MediaType.TV,
+                         media_kind(MEDIA_KIND_TVSHOW))
+        self.assertEqual(MediaType.TV,
+                         media_kind(MEDIA_KIND_TVSHOW2))
+
+    def test_unknown_media_kind_throws(self):
+        with self.assertRaises(exceptions.UnknownMediaKindError):
+            media_kind(99999)
+
+    # PLAYSTATE TESTS
+
+    def test_device_state_no_media(self):
+        # This test should not really be here as "None" is in reality not a
+        # valid value. But it is supported nonetheless because that makes
+        # usage nicer. None means that the field is not included in a
+        # server response, which matches the behavior of dmap.first.
+        self.assertEqual(DeviceState.Idle,
+                         playstate(None))
+
+    def test_regular_playstates(self):
+        self.assertEqual(DeviceState.Idle,
+                         playstate(PLAY_STATE_IDLE))
+        self.assertEqual(DeviceState.Loading,
+                         playstate(PLAY_STATE_LOADING))
+        self.assertEqual(DeviceState.Stopped,
+                         playstate(PLAY_STATE_STOPPED))
+        self.assertEqual(DeviceState.Paused,
+                         playstate(PLAY_STATE_PAUSED))
+        self.assertEqual(DeviceState.Playing,
+                         playstate(PLAY_STATE_PLAYING))
+        self.assertEqual(DeviceState.Seeking,
+                         playstate(PLAY_STATE_FORWARD))
+        self.assertEqual(DeviceState.Seeking,
+                         playstate(PLAY_STATE_BACKWARD))
+
+    def test_unknown_playstate_throws(self):
+        with self.assertRaises(exceptions.UnknownPlayStateError):
+            playstate(99999)
+
+    # TIME TESTS
+
+    def test_no_time_returns_zero(self):
+        self.assertEqual(0, ms_to_s(None))
+
+    def test_time_in_seconds(self):
+        self.assertEqual(0, ms_to_s(400))
+        self.assertEqual(1, ms_to_s(501))
+        self.assertEqual(36, ms_to_s(36000))
+
+    def test_invalid_time(self):
+        # Sometimes really large times are reported during buffering, this test
+        # handles those special cases.
+        self.assertEqual(0, ms_to_s(2**32 - 1))

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -2,103 +2,12 @@
 
 import unittest
 
-from pyatv import (convert, exceptions)
+from pyatv import convert
 from pyatv.const import (
     Protocol, MediaType, DeviceState, RepeatState, ShuffleState)
 
-# These are extracted from iTunes, see for instance:
-# http://www.blooming.no/wp-content/uploads/2013/03/ITLibMediaItem.h
-# and also this:
-# https://github.com/melloware/dacp-net/blob/master/Melloware.DACP/DACPResponse.cs
-# Key: cmst.cmmk
-MEDIA_KIND_UNKNOWN = 1
-MEDIA_KIND_UNKNOWN2 = 32770  # Reported in #182
-MEDIA_KIND_SONG = 2
-MEDIA_KIND_MOVIE = 3
-MEDIA_KIND_PODCAST = 4
-MEDIA_KIND_AUDIOBOOK = 5
-MEDIA_KIND_PDFBOOKLET = 6
-MEDIA_KIND_MUSICVIDEO = 7
-MEDIA_KIND_TVSHOW = 8
-MEDIA_KIND_INTERACTIVEBOOKLET = 9
-MEDIA_KIND_COACHEDAUDIO = 10
-MEDIA_KIND_VIDEOPASS = 11
-MEDIA_KIND_HOMEVIDEO = 12
-MEDIA_KIND_FUTUREVIDEO = 13
-MEDIA_KIND_RINGTONE = 14
-MEDIA_KIND_DIGITALBOOKLET = 15
-MEDIA_KIND_IOSAPPLICATION = 16
-MEDIA_KIND_VOICEMEMO = 17
-MEDIA_KIND_ITUNESU = 18
-MEDIA_KIND_BOOK = 19
-MEDIA_KIND_PDFBOOK = 20
-MEDIA_KIND_ALERTTONE = 21
-MEDIA_KIND_MUSICVIDEO2 = 32
-MEDIA_KIND_PODCAST2 = 36
-MEDIA_KIND_TVSHOW2 = 64
-
-# Found on various places on the Internet as well as by testing
-# Key: cmst.caps
-PLAY_STATE_IDLE = 0
-PLAY_STATE_LOADING = 1  # E.g. buffering
-PLAY_STATE_STOPPED = 2
-PLAY_STATE_PAUSED = 3
-PLAY_STATE_PLAYING = 4
-PLAY_STATE_FORWARD = 5
-PLAY_STATE_BACKWARD = 6
-
 
 class ConvertTest(unittest.TestCase):
-
-    # MEDIA KIND TESTS
-
-    def test_unknown_media_kind(self):
-        self.assertEqual(MediaType.Unknown,
-                         convert.media_kind(MEDIA_KIND_UNKNOWN))
-        self.assertEqual(MediaType.Unknown,
-                         convert.media_kind(MEDIA_KIND_UNKNOWN2))
-
-    def test_video_media_kinds(self):
-        self.assertEqual(MediaType.Video,
-                         convert.media_kind(MEDIA_KIND_MOVIE))
-        self.assertEqual(MediaType.Video,
-                         convert.media_kind(MEDIA_KIND_MUSICVIDEO))
-        self.assertEqual(MediaType.Video,
-                         convert.media_kind(MEDIA_KIND_MUSICVIDEO2))
-        self.assertEqual(MediaType.Video,
-                         convert.media_kind(MEDIA_KIND_VIDEOPASS))
-        self.assertEqual(MediaType.Video,
-                         convert.media_kind(MEDIA_KIND_HOMEVIDEO))
-        self.assertEqual(MediaType.Video,
-                         convert.media_kind(MEDIA_KIND_FUTUREVIDEO))
-        self.assertEqual(MediaType.Video,
-                         convert.media_kind(MEDIA_KIND_ITUNESU))
-
-    def test_music_media_kinds(self):
-        self.assertEqual(MediaType.Music,
-                         convert.media_kind(MEDIA_KIND_SONG))
-        self.assertEqual(MediaType.Music,
-                         convert.media_kind(MEDIA_KIND_PODCAST))
-        self.assertEqual(MediaType.Music,
-                         convert.media_kind(MEDIA_KIND_PODCAST2))
-        self.assertEqual(MediaType.Music,
-                         convert.media_kind(MEDIA_KIND_COACHEDAUDIO))
-        self.assertEqual(MediaType.Music,
-                         convert.media_kind(MEDIA_KIND_RINGTONE))
-        self.assertEqual(MediaType.Music,
-                         convert.media_kind(MEDIA_KIND_VOICEMEMO))
-        self.assertEqual(MediaType.Music,
-                         convert.media_kind(MEDIA_KIND_ALERTTONE))
-
-    def test_tv_kinds(self):
-        self.assertEqual(MediaType.TV,
-                         convert.media_kind(MEDIA_KIND_TVSHOW))
-        self.assertEqual(MediaType.TV,
-                         convert.media_kind(MEDIA_KIND_TVSHOW2))
-
-    def test_unknown_media_kind_throws(self):
-        with self.assertRaises(exceptions.UnknownMediaKindError):
-            convert.media_kind(99999)
 
     def test_media_type_to_string(self):
         self.assertEqual('Unknown',
@@ -112,69 +21,22 @@ class ConvertTest(unittest.TestCase):
     def test_unknown_media_type_to_str(self):
         self.assertEqual('Unsupported', convert.media_type_str(999))
 
-    # PLAYSTATE TESTS
-
-    def test_device_state_no_media(self):
-        # This test should not really be here as "None" is in reality not a
-        # valid value. But it is supported nonetheless because that makes
-        # usage nicer. None means that the field is not included in a
-        # server response, which matches the behavior of dmap.first.
-        self.assertEqual(DeviceState.Idle,
-                         convert.playstate(None))
-
-    def test_regular_playstates(self):
-        self.assertEqual(DeviceState.Idle,
-                         convert.playstate(PLAY_STATE_IDLE))
-        self.assertEqual(DeviceState.Loading,
-                         convert.playstate(PLAY_STATE_LOADING))
-        self.assertEqual(DeviceState.Stopped,
-                         convert.playstate(PLAY_STATE_STOPPED))
-        self.assertEqual(DeviceState.Paused,
-                         convert.playstate(PLAY_STATE_PAUSED))
-        self.assertEqual(DeviceState.Playing,
-                         convert.playstate(PLAY_STATE_PLAYING))
-        self.assertEqual(DeviceState.Seeking,
-                         convert.playstate(PLAY_STATE_FORWARD))
-        self.assertEqual(DeviceState.Seeking,
-                         convert.playstate(PLAY_STATE_BACKWARD))
-
-    def test_unknown_playstate_throws(self):
-        with self.assertRaises(exceptions.UnknownPlayStateError):
-            convert.playstate(99999)
-
-    def test_playstate_str(self):
+    def test_device_state_str(self):
         self.assertEqual('Idle',
-                         convert.playstate_str(DeviceState.Idle))
+                         convert.device_state_str(DeviceState.Idle))
         self.assertEqual('Loading',
-                         convert.playstate_str(DeviceState.Loading))
+                         convert.device_state_str(DeviceState.Loading))
         self.assertEqual('Stopped',
-                         convert.playstate_str(DeviceState.Stopped))
+                         convert.device_state_str(DeviceState.Stopped))
         self.assertEqual('Paused',
-                         convert.playstate_str(DeviceState.Paused))
+                         convert.device_state_str(DeviceState.Paused))
         self.assertEqual('Playing',
-                         convert.playstate_str(DeviceState.Playing))
+                         convert.device_state_str(DeviceState.Playing))
         self.assertEqual('Seeking',
-                         convert.playstate_str(DeviceState.Seeking))
+                         convert.device_state_str(DeviceState.Seeking))
 
-    def test_unsupported_playstate_str(self):
-        self.assertEqual('Unsupported', convert.playstate_str(999))
-
-    # TIME TESTS
-
-    def test_no_time_returns_zero(self):
-        self.assertEqual(0, convert.ms_to_s(None))
-
-    def test_time_in_seconds(self):
-        self.assertEqual(0, convert.ms_to_s(400))
-        self.assertEqual(1, convert.ms_to_s(501))
-        self.assertEqual(36, convert.ms_to_s(36000))
-
-    def test_invalid_time(self):
-        # Sometimes really large times are reported during buffering, this test
-        # handles those special cases.
-        self.assertEqual(0, convert.ms_to_s(2**32 - 1))
-
-    # REPEAT TESTS
+    def test_unsupported_device_state_str(self):
+        self.assertEqual('Unsupported', convert.device_state_str(999))
 
     def test_repeat_str(self):
         self.assertEqual('Off',
@@ -187,8 +49,6 @@ class ConvertTest(unittest.TestCase):
     def test_unknown_repeat_to_str(self):
         self.assertEqual('Unsupported', convert.repeat_str(1234))
 
-    # SHUFFLE TESTS
-
     def test_shuffle_str(self):
         self.assertEqual('Off',
                          convert.shuffle_str(ShuffleState.Off))
@@ -199,8 +59,6 @@ class ConvertTest(unittest.TestCase):
 
     def test_unknown_shuffle_to_str(self):
         self.assertEqual('Unsupported', convert.shuffle_str(1234))
-
-    # PROTOCOL TESTS
 
     def test_protocol_str(self):
         self.assertEqual('MRP',

--- a/tests/test_interface.py
+++ b/tests/test_interface.py
@@ -151,7 +151,7 @@ class InterfaceTest(unittest.TestCase):
     def test_playing_media_type_and_playstate(self):
         out = str(PlayingDummy())
         self.assertIn(convert.media_type_str(MediaType.Video), out)
-        self.assertIn(convert.playstate_str(DeviceState.Playing), out)
+        self.assertIn(convert.device_state_str(DeviceState.Playing), out)
 
     def test_playing_title_artist_album_genre(self):
         out = str(PlayingDummy(


### PR DESCRIPTION
Move out DMAP related code from convert.py and make what is remaining
part of the public interface.

Fixes #469.